### PR TITLE
Add Message Class Generator

### DIFF
--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/context/Context.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/context/Context.java
@@ -1,0 +1,39 @@
+package net.okocraft.chronus.messageclassgenerator.context;
+
+import net.okocraft.chronus.messageclassgenerator.node.RootNode;
+import net.okocraft.chronus.messageclassgenerator.option.GetterOption;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.UnaryOperator;
+
+public record Context(Path directory, String packageName, String className,
+                      GetterOption getterOption,
+                      UnaryOperator<String> fieldNameFilter,
+                      Map<String, String> messageMap,
+                      BiConsumer<RootNode, Context> messageProcessor) {
+
+    public Context(Path directory, String packageName, String className,
+                   GetterOption getterOption,
+                   UnaryOperator<String> fieldNameFilter,
+                   Map<String, String> messageMap,
+                   BiConsumer<RootNode, Context> messageProcessor) {
+        this.directory = Objects.requireNonNull(directory);
+        this.packageName = Objects.requireNonNull(packageName);
+        this.className = Objects.requireNonNull(className);
+        this.getterOption = copy(getterOption); // Copying makes it effectively immutable.
+        this.fieldNameFilter = Objects.requireNonNullElse(fieldNameFilter, UnaryOperator.identity());
+        this.messageMap = Objects.requireNonNull(messageMap); // This is not copied here, as it is the result of reading the file.
+        this.messageProcessor = Objects.requireNonNull(messageProcessor);
+    }
+
+    private static GetterOption copy(GetterOption option) {
+        var copied = new GetterOption();
+        copied.fieldName = Objects.requireNonNullElse(option.fieldName, "MESSAGES");
+        copied.methodName = Objects.requireNonNullElse(option.methodName, "get");
+        copied.getterType = Objects.requireNonNullElse(option.getterType, GetterOption.Type.GETTER_METHOD);
+        return copied;
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/generator/ClassGenerator.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/generator/ClassGenerator.java
@@ -1,0 +1,44 @@
+package net.okocraft.chronus.messageclassgenerator.generator;
+
+import net.okocraft.chronus.messageclassgenerator.context.Context;
+import net.okocraft.chronus.messageclassgenerator.node.RootNode;
+import net.okocraft.chronus.messageclassgenerator.util.IndentingWriter;
+import net.okocraft.chronus.messageclassgenerator.util.Naming;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+
+public final class ClassGenerator {
+
+    public static void generate(Context context) {
+        try {
+            generate0(context);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void generate0(Context context) throws IOException {
+        var rootNode = new RootNode(context.packageName(), context.className());
+
+        context.messageProcessor().accept(rootNode, context);
+
+        var outputDir = Naming.resolvePackagePath(context.directory(), context.packageName());
+
+        if (!Files.isDirectory(outputDir)) {
+            Files.createDirectories(outputDir);
+        }
+
+        var outputFile = outputDir.resolve(context.className() + ".java");
+
+        try (var writer = Files.newBufferedWriter(outputFile, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            rootNode.write(new IndentingWriter(writer));
+        }
+    }
+
+    private ClassGenerator() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/node/ClassNode.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/node/ClassNode.java
@@ -1,0 +1,54 @@
+package net.okocraft.chronus.messageclassgenerator.node;
+
+import net.okocraft.chronus.messageclassgenerator.util.IndentingWriter;
+import net.okocraft.chronus.messageclassgenerator.util.JavadocGenerator;
+import net.okocraft.chronus.messageclassgenerator.util.Naming;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class ClassNode implements Node {
+
+    private final Map<String, Node> map = new LinkedHashMap<>();
+    private final String fieldName;
+    private final String fullKey;
+
+    public ClassNode(String fieldName, String fullKey) {
+        this.fieldName = fieldName;
+        this.fullKey = fullKey;
+    }
+
+    public boolean hasNode(@NotNull String fieldName) {
+        return map.containsKey(fieldName);
+    }
+
+    public @NotNull Node getOrCreateClassNode(@NotNull String fieldName, @NotNull String fullKey) {
+        return map.computeIfAbsent(fieldName, $ -> new ClassNode(fieldName, fullKey));
+    }
+
+    public void putFieldNode(@NotNull String fieldName, @NotNull String fullKey, @NotNull String message) {
+        map.put(fieldName, new FieldNode(fieldName, fullKey, message, false));
+    }
+
+    @Override
+    public void write(@NotNull IndentingWriter writer) {
+        var className = Naming.toClassName(fullKey);
+
+        JavadocGenerator.generate(writer, "A " + JavadocGenerator.classLink(className) + " instance holding messages that are under the key '{@code " + fullKey + "}'");
+        writer.writeLine("public final " + className + " " + fieldName + " = new " + className + "();");
+        writer.writeEmptyLine();
+        JavadocGenerator.generate(writer, "A class holding messages that are under the key '{@code " + fullKey + "}'");
+        writer.writeLine("public static final class " + className + " {");
+        writer.increaseIndent();
+
+        writer.writeEmptyLine();
+        writer.writeLine("private " + className + "() {");
+        writer.writeLine("}");
+
+        Node.writeNodes(map.values(), writer);
+        writer.decreaseIndent();
+
+        writer.writeLine("}");
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/node/FieldNode.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/node/FieldNode.java
@@ -1,0 +1,16 @@
+package net.okocraft.chronus.messageclassgenerator.node;
+
+import net.okocraft.chronus.messageclassgenerator.util.IndentingWriter;
+import net.okocraft.chronus.messageclassgenerator.util.JavadocGenerator;
+
+public record FieldNode(String fieldName, String fullKey, String message, boolean staticField) implements Node {
+
+    @Override
+    public void write(IndentingWriter writer) {
+        JavadocGenerator.generate(writer, "key: {@code " + fullKey + "}<br/>", "message: " + message.replace("<", "&lt;").replace(">", "&gt;"));
+
+        var prefix = staticField ? "public static" : "public";
+        writer.writeLine(prefix + " final TranslatableComponent " + fieldName + " = Component.translatable(\"" + fullKey + "\");");
+    }
+
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/node/InstanceGetterNode.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/node/InstanceGetterNode.java
@@ -1,0 +1,53 @@
+package net.okocraft.chronus.messageclassgenerator.node;
+
+import net.okocraft.chronus.messageclassgenerator.util.IndentingWriter;
+import net.okocraft.chronus.messageclassgenerator.util.JavadocGenerator;
+
+public final class InstanceGetterNode {
+
+    public static Node staticConstant(String className, String fieldName) {
+        return new StaticConstantNode(className, fieldName);
+    }
+
+    public static Node getter(String className, String getterName) {
+        return new StaticConstantNode(className, getterName);
+    }
+
+    record StaticConstantNode(String className, String fieldName) implements Node {
+        @Override
+        public void write(IndentingWriter writer) {
+            write(writer, true);
+        }
+
+        void write(IndentingWriter writer, boolean isPublic) {
+            if (isPublic) {
+                JavadocGenerator.generate(writer, "A " + JavadocGenerator.classLink(className) + " instance.");
+            }
+
+            var accessLevel = isPublic ? "public" : "private";
+            writer.writeLine(accessLevel + " static final " + className + " " + fieldName + " = new " + className + "();");
+            writer.writeEmptyLine();
+            writer.writeLine("private " + className + "() {");
+            writer.writeLine("}");
+        }
+    }
+
+    record GetterNode(String className, String getterName) implements Node {
+
+        private static final String INSTANCE_FIELD_NAME = "INSTANCE";
+
+        @Override
+        public void write(IndentingWriter writer) {
+            new StaticConstantNode(className, INSTANCE_FIELD_NAME).write(writer, false);
+
+            writer.writeEmptyLine();
+            var doc = "the " + JavadocGenerator.classLink(className) + "instance";
+            JavadocGenerator.generate(writer, "Gets" + doc + ".", "", "@returns " + doc);
+            writer.writeLine("public static " + className + " " + getterName + "() {");
+            writer.increaseIndent();
+            writer.writeLine("return " + INSTANCE_FIELD_NAME + ";");
+            writer.decreaseIndent();
+            writer.writeLine("}");
+        }
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/node/Node.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/node/Node.java
@@ -1,0 +1,25 @@
+package net.okocraft.chronus.messageclassgenerator.node;
+
+import net.okocraft.chronus.messageclassgenerator.util.IndentingWriter;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+public sealed interface Node permits RootNode, ClassNode, FieldNode, InstanceGetterNode.GetterNode, InstanceGetterNode.StaticConstantNode {
+
+    void write(IndentingWriter writer);
+
+    static void writeNodes(@NotNull Collection<Node> nodes, @NotNull IndentingWriter writer) {
+        int count = 0;
+        int size = nodes.size();
+
+        for (var node : nodes) {
+            writer.writeEmptyLine();
+            node.write(writer);
+
+            if (++count == size) {
+                writer.writeEmptyLine();
+            }
+        }
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/node/RootNode.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/node/RootNode.java
@@ -1,0 +1,68 @@
+package net.okocraft.chronus.messageclassgenerator.node;
+
+import net.okocraft.chronus.messageclassgenerator.util.IndentingWriter;
+import net.okocraft.chronus.messageclassgenerator.util.JavadocGenerator;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class RootNode implements Node {
+
+    private final Map<String, Node> rootMap = new LinkedHashMap<>();
+
+    private final String packageName;
+    private final String className;
+    private Node instanceGetter;
+
+    public RootNode(String packageName, String className) {
+        this.packageName = packageName;
+        this.className = className;
+    }
+
+    public void addInstanceGetter(Node getter) {
+        this.instanceGetter = getter;
+    }
+
+    public boolean hasNode(String fieldName) {
+        return rootMap.containsKey(fieldName);
+    }
+
+    public Node getOrCreateClassNode(String fieldName, String parentKeys) {
+        return rootMap.computeIfAbsent(fieldName, $ -> new ClassNode(fieldName, parentKeys));
+    }
+
+    public void putFieldNode(String fieldName, String fullKey, String message, boolean staticField) {
+        rootMap.put(fieldName, new FieldNode(fieldName, fullKey, message, staticField));
+    }
+
+    public void clear() {
+        rootMap.clear();
+    }
+
+    @Override
+    public void write(IndentingWriter writer) {
+        if (!packageName.isEmpty()) {
+            writer.writeLine("package " + packageName + ";");
+            writer.writeEmptyLine();
+        }
+
+        writer.writeLine("import net.kyori.adventure.text.Component;");
+        writer.writeLine("import net.kyori.adventure.text.TranslatableComponent;");
+        writer.writeEmptyLine();
+
+        JavadocGenerator.generate(writer, "A auto-generated class of messages.");
+        writer.writeLine("public final class " + className + " {");
+
+        writer.increaseIndent();
+
+        if (instanceGetter != null) {
+            writer.writeEmptyLine();
+            instanceGetter.write(writer);
+        }
+
+        Node.writeNodes(rootMap.values(), writer);
+        writer.decreaseIndent();
+
+        writer.writeLine("}");
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/option/GetterOption.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/option/GetterOption.java
@@ -1,0 +1,16 @@
+package net.okocraft.chronus.messageclassgenerator.option;
+
+public class GetterOption {
+
+    public Type getterType;
+
+    public String methodName;
+
+    public String fieldName;
+
+    public enum Type {
+        GETTER_METHOD,
+        STATIC_CONSTANT,
+        NONE
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/processor/PropertiesProcessor.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/processor/PropertiesProcessor.java
@@ -1,0 +1,44 @@
+package net.okocraft.chronus.messageclassgenerator.processor;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+public final class PropertiesProcessor {
+
+    public static Map<String, String> load(Path filepath) {
+        var filename = filepath.getFileName();
+
+        if (filename == null || !filename.toString().endsWith(".properties")) {
+            return Collections.emptyMap();
+        }
+
+        var properties = new Properties();
+
+        try (var reader = Files.newBufferedReader(filepath)) {
+            properties.load(reader);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return PropertiesProcessor.process(properties);
+    }
+
+    public static Map<String, String> process(Properties properties) {
+        var result = new HashMap<String, String>(properties.size(), 2.0f);
+
+        for (var entry : properties.entrySet()) {
+            if (entry.getKey() instanceof String key && entry.getValue() instanceof String value) {
+                result.put(key, value);
+            } else {
+                throw new IllegalStateException("key or value is not String (key: " + entry.getKey() + " value: " + entry.getValue());
+            }
+        }
+
+        return result;
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/processor/message/ClassAndField.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/processor/message/ClassAndField.java
@@ -1,0 +1,86 @@
+package net.okocraft.chronus.messageclassgenerator.processor.message;
+
+import net.okocraft.chronus.messageclassgenerator.context.Context;
+import net.okocraft.chronus.messageclassgenerator.node.ClassNode;
+import net.okocraft.chronus.messageclassgenerator.node.InstanceGetterNode;
+import net.okocraft.chronus.messageclassgenerator.node.Node;
+import net.okocraft.chronus.messageclassgenerator.node.RootNode;
+import net.okocraft.chronus.messageclassgenerator.option.GetterOption;
+import net.okocraft.chronus.messageclassgenerator.util.Naming;
+
+import java.util.Objects;
+
+final class ClassAndField {
+
+    private final RootNode rootNode;
+    private final Context context;
+
+    ClassAndField(RootNode rootNode, Context context) {
+        this.rootNode = rootNode;
+        this.context = context;
+
+        addGetter();
+    }
+
+    private void addGetter() {
+        var getterType = context.getterOption().getterType;
+
+        if (getterType == GetterOption.Type.GETTER_METHOD) {
+            rootNode.addInstanceGetter(InstanceGetterNode.getter(context.className(), context.getterOption().methodName));
+        } else if (getterType == GetterOption.Type.STATIC_CONSTANT) {
+            rootNode.addInstanceGetter(InstanceGetterNode.staticConstant(context.className(), context.getterOption().fieldName));
+        }
+    }
+
+    void processMessage(String fullKey, String message) {
+        Objects.requireNonNull(fullKey);
+        Objects.requireNonNull(message);
+
+        String[] elements = MessageProcessor.KEY_SEPARATOR.split(fullKey);
+        int i = 0;
+        int last = elements.length - 1;
+
+        ClassNode node = null;
+        var parentKey = new StringBuilder();
+
+        while (i < last) {
+            if (i != 0) {
+                parentKey.append(".");
+            }
+
+            parentKey.append(elements[i]);
+
+            Node nextNode;
+            var fieldName = Naming.toFieldName(elements[i]);
+
+            if (node == null) {
+                nextNode = rootNode.getOrCreateClassNode(fieldName, parentKey.toString());
+            } else {
+                nextNode = node.getOrCreateClassNode(fieldName, parentKey.toString());
+            }
+
+            if (nextNode.getClass() != ClassNode.class) {
+                throw new IllegalStateException(fieldName + " is not ClassNode. Does the key already have a message?");
+            }
+
+            node = (ClassNode) nextNode;
+            i++;
+        }
+
+        var fieldName = Naming.toFieldName(elements[last]);
+
+        if (node == null) {
+            if (rootNode.hasNode(fieldName)) {
+                throw new IllegalStateException("The '" + fieldName + "' field already exists. Are there duplicate keys?");
+            }
+
+            rootNode.putFieldNode(fieldName, fullKey, message, false);
+        } else {
+            if (node.hasNode(fieldName)) {
+                throw new IllegalStateException("The '" + fieldName + "' field already exists. Are there duplicate keys?");
+            }
+
+            node.putFieldNode(fieldName, fullKey, message);
+        }
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/processor/message/ConstantField.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/processor/message/ConstantField.java
@@ -1,0 +1,32 @@
+package net.okocraft.chronus.messageclassgenerator.processor.message;
+
+import net.okocraft.chronus.messageclassgenerator.context.Context;
+import net.okocraft.chronus.messageclassgenerator.node.RootNode;
+import net.okocraft.chronus.messageclassgenerator.util.Naming;
+
+import java.util.Objects;
+
+final class ConstantField {
+
+    private final RootNode rootNode;
+    private final Context context;
+
+    ConstantField(RootNode rootNode, Context context) {
+        this.rootNode = rootNode;
+        this.context = context;
+    }
+
+    void processMessage(String fullKey, String message) {
+        Objects.requireNonNull(fullKey);
+        Objects.requireNonNull(message);
+
+        var filteredKey = context.fieldNameFilter().apply(fullKey);
+        var fieldName = Naming.toConstantFieldName(filteredKey);
+
+        if (rootNode.hasNode(fieldName)) {
+            throw new IllegalStateException(fieldName + " already exists. Are there any duplicate keys after filtering?");
+        }
+
+        rootNode.putFieldNode(fieldName, fullKey, message, true);
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/processor/message/MessageProcessor.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/processor/message/MessageProcessor.java
@@ -1,0 +1,34 @@
+package net.okocraft.chronus.messageclassgenerator.processor.message;
+
+import net.okocraft.chronus.messageclassgenerator.context.Context;
+import net.okocraft.chronus.messageclassgenerator.node.RootNode;
+import net.okocraft.chronus.messageclassgenerator.task.GenerateMessageClass;
+
+import java.util.function.BiConsumer;
+import java.util.regex.Pattern;
+
+public interface MessageProcessor {
+
+    Pattern KEY_SEPARATOR = Pattern.compile(".", Pattern.LITERAL);
+
+    static void classAndFields(RootNode rootNode, Context context, boolean throwError) {
+        processMessage(rootNode, context, new ClassAndField(rootNode, context)::processMessage, throwError);
+    }
+
+    static void constantField(RootNode rootNode, Context context, boolean throwError) {
+        processMessage(rootNode, context, new ConstantField(rootNode, context)::processMessage, throwError);
+    }
+
+    static void processMessage(RootNode rootNode, Context context, BiConsumer<String, String> processor, boolean throwError) {
+        try {
+            context.messageMap().forEach(processor);
+        } catch (IllegalStateException e) {
+            if (throwError) {
+                throw e;
+            } else {
+                GenerateMessageClass.LOGGER.error(e.getMessage());
+                rootNode.clear();
+            }
+        }
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/source/DirectorySource.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/source/DirectorySource.java
@@ -1,0 +1,77 @@
+package net.okocraft.chronus.messageclassgenerator.source;
+
+import net.okocraft.chronus.messageclassgenerator.option.GetterOption;
+import net.okocraft.chronus.messageclassgenerator.processor.PropertiesProcessor;
+import net.okocraft.chronus.messageclassgenerator.util.Naming;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class DirectorySource implements MessageSourceSupplier, Watchable {
+
+    public final Path directory;
+    public final GetterOption getterOption = new GetterOption();
+
+    public String rootPackageName;
+
+    public Function<String, String> filenameToClassNameFunction = filename -> Naming.toClassName(filename.replace(".properties", "")) + "Messages";
+
+    public DirectorySource(Path directory) {
+        this.directory = directory;
+    }
+
+    @SuppressWarnings("resource")
+    @Override
+    public Stream<MessageSource> stream() {
+        if (!Files.isDirectory(directory)) {
+            return Stream.empty();
+        }
+
+        try {
+            return Files.walk(directory).filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().endsWith(".properties"))
+                    .map(this::createMessageSource);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Path directory() {
+        return directory;
+    }
+
+    @Override
+    public @Nullable MessageSource createSource(Path changedPath) {
+        if (Files.isRegularFile(changedPath) && changedPath.getFileName().toString().endsWith(".properties")) {
+            return createMessageSource(changedPath.toAbsolutePath());
+        } else {
+            return null;
+        }
+    }
+
+    private MessageSource createMessageSource(Path filepath) {
+        return new MessageSource(
+                createPackageName(directory.relativize(filepath.getParent())),
+                filenameToClassNameFunction.apply(filepath.getFileName().toString()),
+                getterOption,
+                PropertiesProcessor.load(filepath)
+        );
+    }
+
+    private String createPackageName(Path relativePath) {
+        var relativePackageName = Naming.toPackageName(relativePath);
+
+        if (rootPackageName.isEmpty()) {
+            return relativePackageName;
+        } else {
+            return relativePackageName.isEmpty() ?
+                    rootPackageName :
+                    rootPackageName + "." + relativePackageName;
+        }
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/source/MessageSource.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/source/MessageSource.java
@@ -1,0 +1,8 @@
+package net.okocraft.chronus.messageclassgenerator.source;
+
+import net.okocraft.chronus.messageclassgenerator.option.GetterOption;
+
+import java.util.Map;
+
+public record MessageSource(String packageName, String className, GetterOption getterOption, Map<String, String> messageMap) {
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/source/MessageSourceSupplier.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/source/MessageSourceSupplier.java
@@ -1,0 +1,9 @@
+package net.okocraft.chronus.messageclassgenerator.source;
+
+import java.util.stream.Stream;
+
+public interface MessageSourceSupplier {
+
+    Stream<MessageSource> stream();
+
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/source/PropertiesFileSource.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/source/PropertiesFileSource.java
@@ -1,0 +1,51 @@
+package net.okocraft.chronus.messageclassgenerator.source;
+
+import net.okocraft.chronus.messageclassgenerator.option.GetterOption;
+import net.okocraft.chronus.messageclassgenerator.processor.PropertiesProcessor;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class PropertiesFileSource implements MessageSourceSupplier, Watchable {
+
+    public final Path filepath;
+    public final GetterOption getterOption = new GetterOption();
+
+    public PropertiesFileSource(Path filepath) {
+        this.filepath = filepath;
+    }
+
+    public String packageName;
+    public String className;
+
+    @Override
+    public Stream<MessageSource> stream() {
+        if (!Files.isRegularFile(filepath)) {
+            return Stream.of(createMessageSource(Collections.emptyMap()));
+        }
+
+        return Stream.of(createMessageSource());
+    }
+
+    @Override
+    public Path directory() {
+        return filepath.normalize().getParent();
+    }
+
+    @Override
+    public @Nullable MessageSource createSource(Path changedPath) {
+        return changedPath.getFileName().equals(filepath.getFileName()) ? createMessageSource() : null;
+    }
+
+    private MessageSource createMessageSource() {
+        return createMessageSource(PropertiesProcessor.load(filepath));
+    }
+
+    private MessageSource createMessageSource(Map<String, String> messageMap) {
+        return new MessageSource(packageName, className, getterOption, messageMap);
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/source/Watchable.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/source/Watchable.java
@@ -1,0 +1,13 @@
+package net.okocraft.chronus.messageclassgenerator.source;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+
+public interface Watchable {
+
+    Path directory();
+
+    @Nullable MessageSource createSource(Path changedPath);
+
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/task/CollectMessagesFromAllProject.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/task/CollectMessagesFromAllProject.java
@@ -1,0 +1,54 @@
+package net.okocraft.chronus.messageclassgenerator.task;
+
+import kotlin.io.FilesKt;
+import net.okocraft.chronus.messageclassgenerator.source.MessageSource;
+import net.okocraft.chronus.messageclassgenerator.util.CacheDir;
+import net.okocraft.chronus.messageclassgenerator.util.IndentingWriter;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CollectMessagesFromAllProject extends DefaultTask {
+
+    @SuppressWarnings({"FieldMayBeFinal", "FieldCanBeLocal"})
+    private String outputMessageFilename = "messages_en.properties";
+
+    @TaskAction
+    public void execute() throws IOException {
+        var resourceDir = CacheDir.create(getProject()).resolve("generated-resources");
+
+        if (Files.isDirectory(resourceDir)) {
+            FilesKt.deleteRecursively(resourceDir.toFile());
+        }
+
+        var collectedMessages = new HashMap<String, String>(100, 1.0f);
+
+        for (var project : getProject().getRootProject().getAllprojects()) {
+            if (!(project.getTasks().findByName("generateMessageClass") instanceof GenerateMessageClass task) || task.messageSourceSupplier == null) {
+                continue;
+            }
+
+            try (var stream = task.messageSourceSupplier.stream()) {
+                stream.map(MessageSource::messageMap).forEach(collectedMessages::putAll);
+            }
+        }
+
+        Files.createDirectories(resourceDir);
+
+        var outputFile = resourceDir.resolve(outputMessageFilename);
+
+        try (var writer = Files.newBufferedWriter(outputFile, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            var indentingWriter = new IndentingWriter(writer);
+            collectedMessages.entrySet()
+                    .stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .forEachOrdered(entry -> indentingWriter.writeLine(entry.getKey() + "=" + entry.getValue().replace("\\", "\\\\")));
+        }
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/task/GenerateMessageClass.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/task/GenerateMessageClass.java
@@ -1,0 +1,93 @@
+package net.okocraft.chronus.messageclassgenerator.task;
+
+import kotlin.io.FilesKt;
+import net.okocraft.chronus.messageclassgenerator.context.Context;
+import net.okocraft.chronus.messageclassgenerator.generator.ClassGenerator;
+import net.okocraft.chronus.messageclassgenerator.processor.message.MessageProcessor;
+import net.okocraft.chronus.messageclassgenerator.source.DirectorySource;
+import net.okocraft.chronus.messageclassgenerator.source.MessageSource;
+import net.okocraft.chronus.messageclassgenerator.source.MessageSourceSupplier;
+import net.okocraft.chronus.messageclassgenerator.source.PropertiesFileSource;
+import net.okocraft.chronus.messageclassgenerator.util.CacheDir;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.TaskAction;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
+
+public class GenerateMessageClass extends DefaultTask {
+
+    public static final Logger LOGGER = Logging.getLogger(GenerateMessageClass.class);
+
+    public MessageSourceSupplier messageSourceSupplier;
+    public String removingKeyFilter;
+
+    public GenerateMessageClass() {
+        setGroup("message generator");
+    }
+
+    @TaskAction
+    public void execute() {
+        if (this.messageSourceSupplier == null) {
+            return;
+        }
+
+        var classDir = CacheDir.create(getProject()).resolve("generated-classes");
+
+        if (Files.isDirectory(classDir)) {
+            FilesKt.deleteRecursively(classDir.toFile());
+        }
+
+        try (var stream = this.messageSourceSupplier.stream()) {
+            stream.forEach(source -> execute(source, true));
+        }
+    }
+
+    public void execute(MessageSource messageSource, boolean throwError) {
+        var classDir = CacheDir.create(getProject()).resolve("generated-classes");
+        ClassGenerator.generate(createContext(messageSource, classDir, throwError));
+    }
+
+    private Context createContext(MessageSource source, Path classDir, boolean throwError) {
+        return new Context(
+                classDir,
+                source.packageName(),
+                source.className(),
+                source.getterOption(),
+                removingKeyFilter != null ? new RegexFilter(Pattern.compile(removingKeyFilter)) : null,
+                source.messageMap(),
+                ((rootNode, context1) -> MessageProcessor.constantField(rootNode, context1, throwError))
+        );
+    }
+
+    private record RegexFilter(Pattern pattern) implements UnaryOperator<String> {
+        @Override
+        public String apply(String text) {
+            return pattern.matcher(text).replaceAll("");
+        }
+    }
+
+    public PropertiesFileSource fromPropertiesFile(Path file) {
+        return new PropertiesFileSource(file);
+    }
+
+    public DirectorySource fromDirectory(Path directory) {
+        return new DirectorySource(directory);
+    }
+
+    public PropertiesFileSource fromPropertiesFileInResourceDir(String filename) {
+        return fromPropertiesFile(getResourceDir().resolve(filename));
+    }
+
+    public DirectorySource fromDirectoryInResourceDir(UnaryOperator<Path> resourceDirOperator) {
+        return fromDirectory(resourceDirOperator.apply(getResourceDir()));
+    }
+
+    private Path getResourceDir() {
+        return getProject().getLayout().getProjectDirectory().dir("src/main/resources").getAsFile().toPath();
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/util/CacheDir.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/util/CacheDir.java
@@ -1,0 +1,13 @@
+package net.okocraft.chronus.messageclassgenerator.util;
+
+import org.gradle.api.Project;
+
+import java.nio.file.Path;
+
+public final class CacheDir {
+
+    public static Path create(Project project) {
+        return project.getLayout().getProjectDirectory().dir(".gradle/caches").dir("message-class-generator").getAsFile().toPath();
+    }
+
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/util/IndentingWriter.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/util/IndentingWriter.java
@@ -1,0 +1,53 @@
+package net.okocraft.chronus.messageclassgenerator.util;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public class IndentingWriter {
+
+    private static final String LINE_SEPARATOR = System.getProperty("line.separator", "\n");
+    private final Writer writer;
+    private int depth = 0;
+
+    public IndentingWriter(@NotNull Writer writer) {
+        this.writer = writer;
+    }
+
+    public void increaseIndent() {
+        depth++;
+    }
+
+    public void decreaseIndent() {
+        depth--;
+    }
+
+    public void writeLine(@NotNull String line) {
+        writeIndent();
+        write(line);
+        write(LINE_SEPARATOR);
+    }
+
+    public void writeEmptyLine() {
+        write(LINE_SEPARATOR);
+    }
+
+    private void writeIndent() {
+        if (depth == 0) {
+            return;
+        }
+
+        for (int i = 1; i <= depth; i++) {
+            write("    ");
+        }
+    }
+
+    private void write(@NotNull String str) {
+        try {
+            writer.write(str);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/util/JavadocGenerator.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/util/JavadocGenerator.java
@@ -1,0 +1,22 @@
+package net.okocraft.chronus.messageclassgenerator.util;
+
+public final class JavadocGenerator {
+
+    public static void generate(IndentingWriter writer, String... comments) {
+        writer.writeLine("/**");
+
+        for (var comment : comments) {
+            writer.writeLine(" * " + comment);
+        }
+
+        writer.writeLine(" */");
+    }
+
+    public static String classLink(String className) {
+        return "{@link " + className + "}";
+    }
+
+    private JavadocGenerator() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/util/Naming.java
+++ b/build-logic/src/main/java/net/okocraft/chronus/messageclassgenerator/util/Naming.java
@@ -1,0 +1,125 @@
+package net.okocraft.chronus.messageclassgenerator.util;
+
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public final class Naming {
+
+    /**
+     * <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-3.html#jls-3.9">JLS</a>
+     */
+    private static final Set<String> JAVA_KEYWORDS = Set.of(
+            "abstract", "continue", "for", "new", "switch", "assert", "default",
+            "if", "package", "synchronized", "boolean", "do", "goto", "private",
+            "this", "break", "double", "implements", "protected", "throw", "byte",
+            "else", "import", "public", "throws", "case", "enum", "instanceof",
+            "return", "transient", "catch", "extends", "int", "short", "try",
+            "char", "final", "interface", "static", "void", "class", "finally",
+            "long", "strictfp", "volatile", "const", "float", "native", "super", "while"
+    );
+
+    public static String toFieldName(String original) {
+        var builder = new StringBuilder();
+        boolean toUppercase = false;
+
+        for (int codePoint : original.codePoints().toArray()) {
+            boolean isSeparator = codePoint == '-' || codePoint == '_' || codePoint == '.';
+
+            if (isSeparator) {
+                if (toUppercase) {
+                    throw new IllegalArgumentException("invalid: " + original);
+                } else {
+                    toUppercase = true;
+                    continue;
+                }
+            }
+
+            if (toUppercase) {
+                builder.appendCodePoint(Character.toUpperCase(codePoint));
+                toUppercase = false;
+            } else {
+                builder.appendCodePoint(codePoint);
+            }
+        }
+
+        var result = builder.toString();
+
+        if (JAVA_KEYWORDS.contains(result)) {
+            throw new IllegalStateException(result + " is Java's keyword.");
+        }
+
+        return result;
+    }
+
+    public static String toClassName(String original) {
+        return fieldNameToClassName(toFieldName(original));
+    }
+
+    public static String toConstantFieldName(String original) {
+        var builder = new StringBuilder();
+
+        for (int codePoint : original.codePoints().toArray()) {
+            boolean isSeparator = codePoint == '-' || codePoint == '_' || codePoint == '.';
+
+            if (isSeparator) {
+                builder.append('_');
+            } else {
+                builder.appendCodePoint(Character.toUpperCase(codePoint));
+            }
+        }
+
+        return builder.toString();
+    }
+
+    public static String toPackageName(Path relativePath) {
+        var separator = relativePath.getFileSystem().getSeparator();
+        return relativePath.toString().replace(separator, ".");
+    }
+
+    private static final Pattern PACKAGE_SEPARATOR = Pattern.compile(".", Pattern.LITERAL);
+
+    public static Path resolvePackagePath(Path directory, String packageName) {
+        if (packageName.isEmpty()) {
+            return directory;
+        }
+
+        var result = directory;
+
+        for (var element : PACKAGE_SEPARATOR.split(packageName)) {
+            result = result.resolve(element);
+        }
+
+        return result;
+    }
+
+    public static String fieldNameToClassName(String fieldName) {
+        int len = fieldName.length();
+        if (len == 0) {
+            throw new IllegalArgumentException("empty string");
+        }
+
+        // StringUtils#capitalize (commons-lang3)
+        final int firstCodepoint = fieldName.codePointAt(0);
+        final int newCodePoint = Character.toTitleCase(firstCodepoint);
+        if (firstCodepoint == newCodePoint) {
+            // already capitalized
+            return fieldName;
+        }
+
+        final int[] newCodePoints = new int[len]; // cannot be longer than the char array
+        int outOffset = 0;
+        newCodePoints[outOffset++] = newCodePoint; // copy the first codepoint
+        for (int inOffset = Character.charCount(firstCodepoint); inOffset < len; ) {
+            final int codepoint = fieldName.codePointAt(inOffset);
+            newCodePoints[outOffset++] = codepoint; // copy the remaining ones
+            inOffset += Character.charCount(codepoint);
+        }
+
+        return new String(newCodePoints, 0, outOffset);
+    }
+
+    private Naming() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/build-logic/src/main/kotlin/chronus.message-class-generator.gradle.kts
+++ b/build-logic/src/main/kotlin/chronus.message-class-generator.gradle.kts
@@ -1,0 +1,43 @@
+import net.okocraft.chronus.messageclassgenerator.task.GenerateMessageClass
+
+plugins {
+    `java-library`
+    idea
+    id("chronus.common-conventions")
+}
+
+java {
+    sourceSets.main {
+        java {
+            srcDirs(file(".gradle/caches/message-class-generator/generated-classes"))
+        }
+
+        resources {
+            exclude {
+                return@exclude it.isDirectory && it.path.startsWith("messages")
+            }
+        }
+    }
+}
+
+idea {
+    module {
+        val path = file(".gradle/caches/message-class-generator/generated-classes")
+        sourceDirs.add(path)
+        generatedSourceDirs.add(path)
+    }
+}
+
+tasks {
+    build {
+        dependsOn("generateMessageClass")
+    }
+
+    create<GenerateMessageClass>("generateMessageClass") {
+        messageSourceSupplier =
+            fromDirectoryInResourceDir { path -> path.resolve("messages") }.apply {
+                rootPackageName = "net.okocraft.chronus.generated.messages"
+            }
+        removingKeyFilter = "^chronus\\..*?\\."
+    }
+}

--- a/build-logic/src/main/kotlin/chronus.platform-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/chronus.platform-conventions.gradle.kts
@@ -1,3 +1,5 @@
+import net.okocraft.chronus.messageclassgenerator.task.CollectMessagesFromAllProject
+
 plugins {
     `java-library`
     id("com.github.johnrengelman.shadow")
@@ -9,8 +11,20 @@ dependencies {
     implementation(project(":chronus-core"))
 }
 
+java {
+    sourceSets.main {
+        resources {
+            srcDirs(file(".gradle/caches/message-class-generator/generated-resources"))
+        }
+    }
+}
+
 tasks {
+    val collectMessageTask = create<CollectMessagesFromAllProject>("collectMessagesFromAllProject")
+
     processResources {
+        dependsOn(collectMessageTask)
+
         filesMatching(listOf("plugin.yml")) {
             expand("projectVersion" to project.version)
         }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id ("chronus.common-conventions")
+    id ("chronus.message-class-generator")
 }
 
 dependencies {


### PR DESCRIPTION
## 概要

`.properties` ファイルで `key-value` 形式で定義したメッセージに基づき、Adventure の `TranslatableComponent` を定数として宣言したクラスを自動で生成します。

## 使い方

### プロジェクトへの設定

適用したいプロジェクトの `build.gradle.kts` に `chronus.message-class-generator` をプラグインとして追加する。

```patch
 plugins {
+    id ("chronus.message-class-generator")
 }
```

これにより、`generateMessageClass` と `watchMessageFile` タスクが追加される。
`core` モジュールはすでに適用済み。

### メッセージを追加する

デフォルトではプロジェクトディレクトリの `./src/main/resources/messages` 下にメッセージファイルを作成する。
ファイル名はそのファイルの内容を一言で説明するものが望ましい。例えば汎用的なメッセージやエラーメッセージを持つファイルの場合は `general.properties` にする。
このファイル名は `.properties` を抜いてパスカルケースにし、`Messages` を接尾辞としたクラス名になる。この例では `GeneralMessages` がクラス名になる。

メッセージのキーは `chronus.` から始まった英数字で構成するものとする。なお、数字からキーを始めたり、Java にフィールド名に使用できない文字を含むと、生成したクラスはコンパイルできなくなるため注意すること。キーの例としては `chronus.general.no-permission` や `chronus.command.subcommand.help`。

```properties
chronus.general.no-permission=You don't have the permission: {0}
```

### クラスを生成する

クラスを生成するには、`generateMessageClass` タスクを実行する。IntelliJ であれば、Gradle タブの `message generator` カテゴリに該当タスクがあり、クリックすることで実行できる。単純に `./gradlew generateMessageClass` を実行しても可能。

### 生成したクラスの定数を利用する

生成したクラスは `net.okocraft.chronus.generated.messages` 下に存在する。`general.properties` のクラスは `net.okocraft.chronus.generated.messages.GeneralMessages` となる。 `./resources/messages/something/example.properties`  のように配置した場合、パッケージも同様に深くなり、`net.okocraft.chronus.generated.messages.something.ExampleMessages` となる。

定数フィールド名は、キーを `.` で分けた際に、最初の2要素を省いてすべて大文字にし、`_` で繋いだものとなる。`chronus.general.no-permission` は `NO_PERMISSION`、`chronus.command.subcommand.help` は `SUBCOMMAND_HELP` になる。

なお、生成したクラスは一時的には編集可能であるが、ビルド時に再生成され変更が失われるため、極力編集しないこと (IDE からもそのような警告が表示される)。

#### 使用例
```java
public void sendNoPermissionMessage(Audience target) {
    target.sendMessage(GeneralMessages.NO_PERMISSION);
}
```

### メッセージファイルの集約

最終的に配布する Jar を作成するプロジェクト、現在では `chronus-platform-paper` が該当するが、そこですべてのプロジェクトからメッセージを集めて単一の `messages_en.properties` を生成する。なお、重複したキーがあると最初に追加されたメッセージは消える。

## この PR で実現できていないこと

- この機能のプラグイン化
- 最終的なメッセージ管理方法の確定
- コンパイルエラーとなるメッセージキーの完全な検知
- IntelliJ によるプロジェクト同期時のメッセージクラス生成
  - このリポジトリをクローンして Idea で開くと自動的に同期処理が始まるが、そのタイミングでメッセージファイルを生成するロジックは組んでいない (プラグイン化のときに行う予定)
- メッセージファイルの変更を検知してメッセージクラスの自動再生成
- 十分なテスト